### PR TITLE
Ensure Action::pddl_ pointer is always initialized

### DIFF
--- a/include/symbolic/action.h
+++ b/include/symbolic/action.h
@@ -10,6 +10,7 @@
 #ifndef SYMBOLIC_ACTION_H_
 #define SYMBOLIC_ACTION_H_
 
+#include <cassert>     // assert
 #include <functional>  // std::function
 #include <ostream>     // std::ostream
 #include <string>      // std::string
@@ -35,7 +36,9 @@ class Pddl;
 
 class Action {
  public:
-  Action() = default;
+  Action() = delete; // default;
+
+  explicit Action(const Pddl& pddl) : pddl_(&pddl) {};
 
   Action(const Pddl& pddl, const VAL::operator_* symbol);
 
@@ -70,7 +73,10 @@ class Action {
 
   const VAL::operator_* symbol() const { return symbol_; }
 
-  const Pddl& pddl() const { return *pddl_; }
+  const Pddl& pddl() const {
+    assert(pddl_);
+    return *pddl_;
+  }
 
   const std::string& name() const { return name_; }
 

--- a/include/symbolic/derived_predicate.h
+++ b/include/symbolic/derived_predicate.h
@@ -22,6 +22,8 @@ namespace symbolic {
 
 class DerivedPredicate : public Action {
  public:
+  DerivedPredicate() = delete;
+
   DerivedPredicate(const Pddl& pddl, const VAL::derivation_rule* symbol);
 
   const VAL::derivation_rule* symbol() const { return symbol_; }

--- a/src/derived_predicate.cc
+++ b/src/derived_predicate.cc
@@ -17,7 +17,7 @@ namespace symbolic {
 
 DerivedPredicate::DerivedPredicate(const Pddl& pddl,
                                    const VAL::derivation_rule* symbol)
-    : symbol_(symbol) {
+    : Action(pddl), symbol_(symbol) {
   name_ = symbol_->get_head()->head->getName();
   parameters_ = Object::CreateList(pddl, symbol_->get_head()->args);
   param_gen_ = ParameterGenerator(pddl, parameters_);

--- a/src/predicate.cc
+++ b/src/predicate.cc
@@ -18,7 +18,8 @@
 namespace symbolic {
 
 Predicate::Predicate(const Pddl& pddl, const VAL::pred_decl* symbol)
-    : symbol_(symbol),
+    : Action(pddl),
+      symbol_(symbol),
       name_(symbol_->getPred()->getName()),
       parameters_(Object::CreateList(pddl, symbol_->getArgs())),
       param_gen_(ParameterGenerator(pddl, parameters_)) {}


### PR DESCRIPTION
This resolves some potential segfaults that I was seeing when calling `pddl()` on a `Predicate` object